### PR TITLE
Reintroduce node conversion to function builder

### DIFF
--- a/Sources/HTML/NodeBuilder.swift
+++ b/Sources/HTML/NodeBuilder.swift
@@ -29,11 +29,7 @@ public struct NodeBuilder {
     }
 
     public static func buildIf(_ component: Node?) -> Node {
-        if let component = component {
-            return component
-        } else {
-            return .fragment(children: [])
-        }
+        component ?? .fragment(children: [])
     }
 
     public static func buildEither(first: Node) -> Node {
@@ -42,5 +38,11 @@ public struct NodeBuilder {
 
     public static func buildEither(second: Node) -> Node {
         second
+    }
+}
+
+extension NodeBuilder {
+    public static func buildBlock(_ components: NodeConvertible...) -> Node {
+        .fragment(children: components.map { $0.asNode() })
     }
 }

--- a/Tests/HTMLTests/HTMLTests.swift
+++ b/Tests/HTMLTests/HTMLTests.swift
@@ -210,6 +210,29 @@ final class HTMLTests: XCTestCase {
 
         XCTAssertEqual(modified, [ "Hello World!", "This should be extracted", "Lorem ipsum" ])
     }
+
+    func testStringNodeConversion() {
+        let text = "Hallo Welt"
+
+        let root = p {
+            text
+            b {
+                [ text, text ]
+            }
+        }
+
+        XCTAssertTrue(String(describing: root).contains(text))
+    }
+
+    func testArrayNodeConversion() {
+        let numbers = [ 1, 2, 3 ]
+
+        let root = p {
+            numbers.map { "\($0)" }
+        }
+
+        XCTAssertTrue(String(describing: root).contains("1"))
+    }
 }
 
 func XCTAssertComponents(_ node: Node, _ components: String..., message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
This accidentally broke, added a test so it doesn't again (knock on wood).