### PR TITLE
Add empty tags and render non-empty tags correctly

### DIFF
--- a/Scripts/GenerateTags.swift
+++ b/Scripts/GenerateTags.swift
@@ -44,6 +44,8 @@ struct Tag: Decodable, Hashable {
     var name: String
 
     var description: String?
+
+    var isEmpty: Bool?
 }
 
 struct Attribute: Decodable, Hashable {
@@ -92,6 +94,10 @@ for tag in tags {
         }
         .joined(separator: ",\n        ")
 
+    let childrenArgument = tag.isEmpty == true ? "" : ",\n    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }"
+
+    let childrenInvocation = tag.isEmpty == true ? "nil" : "children().asNode()"
+
     let definition = #"""
 /// \#(tag.name)
 ///
@@ -102,8 +108,7 @@ for tag in tags {
 public func \#(tag.name.asSwiftIdentifier)(
     \#(attributeDeclarations),
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...\#(childrenArgument)
 ) -> Node {
     let attributes = [
         \#(attibuteCapture)
@@ -119,7 +124,7 @@ public func \#(tag.name.asSwiftIdentifier)(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "\#(tag.name)", attributes: combined, child: children().asNode())
+    return .element(name: "\#(tag.name)", attributes: combined, child: \#(childrenInvocation))
 }
 
 """#

--- a/Scripts/tags.json
+++ b/Scripts/tags.json
@@ -21,7 +21,8 @@
     },
     {
         "name": "area",
-        "description": "The HTML `<area>` element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a `<map>` element."
+        "description": "The HTML `<area>` element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a `<map>` element.",
+        "isEmpty": true
     },
     {
         "name": "article",
@@ -41,7 +42,8 @@
     },
     {
         "name": "base",
-        "description": "The HTML `<base>` element specifies the base URL to use for all relative URLs contained within a document. There can be only one `<base>` element in a document."
+        "description": "The HTML `<base>` element specifies the base URL to use for all relative URLs contained within a document. There can be only one `<base>` element in a document.",
+        "isEmpty": true
     },
     {
         "name": "basefont",
@@ -77,7 +79,8 @@
     },
     {
         "name": "br",
-        "description": "The HTML `<br>` element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant."
+        "description": "The HTML `<br>` element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant.",
+        "isEmpty": true
     },
     {
         "name": "button",
@@ -105,7 +108,8 @@
     },
     {
         "name": "col",
-        "description": "The HTML `<col>` element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a `<colgroup>` element."
+        "description": "The HTML `<col>` element defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a `<colgroup>` element.",
+        "isEmpty": true
     },
     {
         "name": "colgroup",
@@ -173,7 +177,8 @@
     },
     {
         "name": "embed",
-        "description": "The HTML `<embed>` element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in."
+        "description": "The HTML `<embed>` element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in.",
+        "isEmpty": true
     },
     {
         "name": "fieldset",
@@ -245,7 +250,8 @@
     },
     {
         "name": "hr",
-        "description": "The HTML `<hr>` element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section."
+        "description": "The HTML `<hr>` element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.",
+        "isEmpty": true
     },
     {
         "name": "html",
@@ -265,11 +271,13 @@
     },
     {
         "name": "img",
-        "description": "The HTML `<img>` element embeds an image into the document. It is a replaced element."
+        "description": "The HTML `<img>` element embeds an image into the document. It is a replaced element.",
+        "isEmpty": true
     },
     {
         "name": "input",
-        "description": "The HTML `<input>` element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent."
+        "description": "The HTML `<input>` element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.",
+        "isEmpty": true
     },
     {
         "name": "ins",
@@ -301,7 +309,8 @@
     },
     {
         "name": "link",
-        "description": "The HTML External Resource Link element (`<link>`) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both \"favicon\" style icons and mobile home screen/app icons) among other things."
+        "description": "The HTML External Resource Link element (`<link>`) specifies relationships between the current document and an external resource. This element is most commonly used to link to stylesheets, but is also used to establish site icons (both \"favicon\" style icons and mobile home screen/app icons) among other things.",
+        "isEmpty": true
     },
     {
         "name": "listing",
@@ -333,7 +342,8 @@
     },
     {
         "name": "meta",
-        "description": "The HTML `<meta>` element represents metadata that cannot be represented by other HTML meta-related elements, like `<base>`, `<link>`, `<script>`, `<style>` or `<title>`."
+        "description": "The HTML `<meta>` element represents metadata that cannot be represented by other HTML meta-related elements, like `<base>`, `<link>`, `<script>`, `<style>` or `<title>`.",
+        "isEmpty": true
     },
     {
         "name": "meter",
@@ -393,7 +403,8 @@
     },
     {
         "name": "param",
-        "description": "The HTML `<param>` element defines parameters for an `<object>` element."
+        "description": "The HTML `<param>` element defines parameters for an `<object>` element.",
+        "isEmpty": true
     },
     {
         "name": "picture",
@@ -469,7 +480,8 @@
     },
     {
         "name": "source",
-        "description": "The HTML `<source>` element specifies multiple media resources for the `<picture>`, the `<audio>` element, or the `<video>` element."
+        "description": "The HTML `<source>` element specifies multiple media resources for the `<picture>`, the `<audio>` element, or the `<video>` element.",
+        "isEmpty": true
     },
     {
         "name": "spacer",
@@ -549,7 +561,8 @@
     },
     {
         "name": "track",
-        "description": "The HTML `<track>` element is used as a child of the media elements `<audio>` and `<video>`. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks or Timed Text Markup Language (TTML)."
+        "description": "The HTML `<track>` element is used as a child of the media elements `<audio>` and `<video>`. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks or Timed Text Markup Language (TTML).",
+        "isEmpty": true
     },
     {
         "name": "tt",
@@ -573,7 +586,8 @@
     },
     {
         "name": "wbr",
-        "description": "The HTML `<wbr>` element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location."
+        "description": "The HTML `<wbr>` element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location.",
+        "isEmpty": true
     },
     {
         "name": "xmp",

--- a/Sources/HTML/Tags.swift
+++ b/Sources/HTML/Tags.swift
@@ -502,8 +502,7 @@ public func area(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -547,7 +546,7 @@ public func area(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "area", attributes: combined, child: children().asNode())
+    return .element(name: "area", attributes: combined, child: nil)
 }
 
 /// article
@@ -941,8 +940,7 @@ public func base(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -977,7 +975,7 @@ public func base(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "base", attributes: combined, child: children().asNode())
+    return .element(name: "base", attributes: combined, child: nil)
 }
 
 /// basefont
@@ -1678,8 +1676,7 @@ public func br(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -1712,7 +1709,7 @@ public func br(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "br", attributes: combined, child: children().asNode())
+    return .element(name: "br", attributes: combined, child: nil)
 }
 
 /// button
@@ -2286,8 +2283,7 @@ public func col(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -2323,7 +2319,7 @@ public func col(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "col", attributes: combined, child: children().asNode())
+    return .element(name: "col", attributes: combined, child: nil)
 }
 
 /// colgroup
@@ -3693,8 +3689,7 @@ public func embed(
     type: String? = nil,
     width: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -3731,7 +3726,7 @@ public func embed(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "embed", attributes: combined, child: children().asNode())
+    return .element(name: "embed", attributes: combined, child: nil)
 }
 
 /// fieldset
@@ -5180,8 +5175,7 @@ public func hr(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -5216,7 +5210,7 @@ public func hr(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "hr", attributes: combined, child: children().asNode())
+    return .element(name: "hr", attributes: combined, child: nil)
 }
 
 /// html
@@ -5653,8 +5647,7 @@ public func img(
     usemap: String? = nil,
     width: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -5703,7 +5696,7 @@ public func img(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "img", attributes: combined, child: children().asNode())
+    return .element(name: "img", attributes: combined, child: nil)
 }
 
 /// input
@@ -5813,8 +5806,7 @@ public func input(
     value: String? = nil,
     width: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accept": accept,
@@ -5879,7 +5871,7 @@ public func input(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "input", attributes: combined, child: children().asNode())
+    return .element(name: "input", attributes: combined, child: nil)
 }
 
 /// ins
@@ -6536,8 +6528,7 @@ public func link(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -6579,7 +6570,7 @@ public func link(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "link", attributes: combined, child: children().asNode())
+    return .element(name: "link", attributes: combined, child: nil)
 }
 
 /// listing
@@ -7205,8 +7196,7 @@ public func meta(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -7243,7 +7233,7 @@ public func meta(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "meta", attributes: combined, child: children().asNode())
+    return .element(name: "meta", attributes: combined, child: nil)
 }
 
 /// meter
@@ -8485,8 +8475,7 @@ public func param(
     translate: String? = nil,
     value: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -8521,7 +8510,7 @@ public func param(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "param", attributes: combined, child: children().asNode())
+    return .element(name: "param", attributes: combined, child: nil)
 }
 
 /// picture
@@ -10083,8 +10072,7 @@ public func source(
     translate: String? = nil,
     type: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -10122,7 +10110,7 @@ public func source(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "source", attributes: combined, child: children().asNode())
+    return .element(name: "source", attributes: combined, child: nil)
 }
 
 /// spacer
@@ -11833,8 +11821,7 @@ public func track(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -11872,7 +11859,7 @@ public func track(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "track", attributes: combined, child: children().asNode())
+    return .element(name: "track", attributes: combined, child: nil)
 }
 
 /// tt
@@ -12351,8 +12338,7 @@ public func wbr(
     title: String? = nil,
     translate: String? = nil,
     customData: [String: String] = [:],
-    classes classList: String...,
-    @NodeBuilder children: () -> NodeConvertible = { Node.fragment(children: []) }
+    classes classList: String...
 ) -> Node {
     let attributes = [
         "accesskey": accesskey,
@@ -12385,7 +12371,7 @@ public func wbr(
         combined["data-\(key)"] = value
     }
 
-    return .element(name: "wbr", attributes: combined, child: children().asNode())
+    return .element(name: "wbr", attributes: combined, child: nil)
 }
 
 /// xmp

--- a/Sources/HTML/Visitor.swift
+++ b/Sources/HTML/Visitor.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol Visitor {
     associatedtype Result
 
-    func visitElement(name: String, attributes: [String: String], child: Node) -> Result
+    func visitElement(name: String, attributes: [String: String], child: Node?) -> Result
 
     func visitText(text: String) -> Result
 
@@ -38,8 +38,8 @@ extension Visitor {
 }
 
 public extension Visitor where Result == Node {
-    func visitElement(name: String, attributes: [String: String], child: Node) -> Result {
-        .element(name: name, attributes: attributes, child: visitNode(child))
+    func visitElement(name: String, attributes: [String: String], child: Node?) -> Result {
+        .element(name: name, attributes: attributes, child: child.map(visitNode))
     }
 
     func visitText(text: String) -> Result {

--- a/Tests/HTMLTests/HTMLTests.swift
+++ b/Tests/HTMLTests/HTMLTests.swift
@@ -35,6 +35,16 @@ final class HTMLTests: XCTestCase {
         XCTAssertTrue(String(describing: root).contains("Hello World!"))
     }
 
+    func testEmptyElements() {
+        let emptyElement = br()
+
+        XCTAssertEqual(String(describing: emptyElement), "\n<br/>")
+
+        let nonEmptyElement = p()
+
+        XCTAssertEqual(String(describing: nonEmptyElement), "\n<p>\n</p>")
+    }
+
     func testIfBlock() {
         let root = html {
             h1 { "Test:" }
@@ -167,8 +177,8 @@ final class HTMLTests: XCTestCase {
         struct TextExtractionVisitor: Visitor {
             typealias Result = [String]
 
-            func visitElement(name: String, attributes: [String : String], child: Node) -> [String] {
-                visitNode(child)
+            func visitElement(name: String, attributes: [String : String], child: Node?) -> [String] {
+                child.map(visitNode) ?? []
             }
 
             func visitText(text: String) -> [String] {


### PR DESCRIPTION
This fixes a case where `script(src: "test.js")` would render as `<script src="test.js"/>` which is not valid. It also makes `br { "test" }` a compiler error now.