### PR TITLE
Attributes as ExpressibleByDictionaryLiteral

### DIFF
--- a/Sources/HTML/Tags.swift
+++ b/Sources/HTML/Tags.swift
@@ -3,6 +3,13 @@
 
 @_exported import Swim
 
+extension Node {
+    static func element(_ name: String, _ attributes: [String:String], _ node: Node?) -> Node {
+        Node.element(name, Attributes(attributes: attributes.sorted(by: { $0.key < $1.key }).map(Attribute.init)), node)
+    }
+}
+
+
 
 public struct ATag: Tag {
     public let elementName: String = "a"

--- a/Sources/Swim/Node.swift
+++ b/Sources/Swim/Node.swift
@@ -1,8 +1,29 @@
 import Foundation
 
+public struct Attribute: Hashable {
+    public var key: String
+    public var value: String
+    
+    public init(_ pair: (String, String)) {
+        (self.key, self.value) = pair
+    }
+}
+
+public struct Attributes: ExpressibleByDictionaryLiteral, Hashable {
+    public var attributes: [Attribute]
+   
+    public init(attributes: [Attribute]) {
+        self.attributes = attributes
+    }
+    
+    public init(dictionaryLiteral elements: (String, String)...) {
+        self.attributes = elements.map(Attribute.init)
+    }
+}
+
 public enum Node: Hashable {
     // The `Node`'s name, attribute and children.
-    indirect case element(String, [String: String], Node?)
+    indirect case element(String, Attributes, Node?)
 
     // The `Node`'s text contents.
     case text(String)
@@ -49,14 +70,14 @@ extension Node: TextOutputStreamable {
             target.write("<")
             target.write(name)
 
-            for (key, value) in attributes.sorted(by: { $0 < $1 }) {
+            for attribute in attributes.attributes {
                 target.write(" ")
-                target.write(key)
+                target.write(attribute.key)
 
-                guard value != "" else { continue }
+                guard attribute.value != "" else { continue }
 
                 target.write("=\"")
-                target.write(value.replacingOccurrences(of: "\"", with: "&quot;"))
+                target.write(attribute.value.replacingOccurrences(of: "\"", with: "&quot;"))
                 target.write("\"")
             }
 

--- a/Sources/Swim/Visitor.swift
+++ b/Sources/Swim/Visitor.swift
@@ -3,7 +3,7 @@ import Foundation
 public protocol Visitor {
     associatedtype Result
 
-    func visitElement(name: String, attributes: [String: String], child: Node?) -> Result
+    func visitElement(name: String, attributes: Attributes, child: Node?) -> Result
 
     func visitText(text: String) -> Result
     
@@ -42,7 +42,7 @@ extension Visitor {
 }
 
 public extension Visitor where Result == Node {
-    func visitElement(name: String, attributes: [String: String], child: Node?) -> Result {
+    func visitElement(name: String, attributes: Attributes, child: Node?) -> Result {
         .element(name, attributes, child.map(visitNode))
     }
 

--- a/Tests/HTMLTests/HTMLTests.swift
+++ b/Tests/HTMLTests/HTMLTests.swift
@@ -189,7 +189,7 @@ final class HTMLTests: XCTestCase {
         struct TextExtractionVisitor: Visitor {
             typealias Result = [String]
 
-            func visitElement(name: String, attributes: [String : String], child: Node?) -> [String] {
+            func visitElement(name: String, attributes: Attributes, child: Node?) -> [String] {
                 child.map(visitNode) ?? []
             }
 
@@ -264,7 +264,7 @@ final class HTMLTests: XCTestCase {
         struct Sanitizer: Visitor {
             var denyList: [Tag]
 
-            func visitElement(name: String, attributes: [String : String], child: Node?) -> Node {
+            func visitElement(name: String, attributes: Attributes, child: Node?) -> Node {
                 if denyList.contains(where: { $0.elementName == name }) {
                     let original = Node.element(name, attributes, child)
 


### PR DESCRIPTION
This PR is an experiment, not sure if it's a good idea.

I figured that it's nice to keep the declaration order of attributes.

Previously, we were sorting the attributes alphabetically during pretty printing so that they would at least always print in the same order.

Here are a few things to think about:

- We don't remove duplicate attributes (which should be unnecessary for HTML, unless you have duplicate custom attributes). 
- The way I made `Tags.swift` compile is just a way to get this out without a large diff. But it also shows a problem: if people buildup their attributes using dictionaries, this approach is not nice. We could make `Attributes` conform to more protocols so that it feels just like an (ordered) dictionary.
- There are no tests for this yet
- I'm not sure if the added complexity is worth it over a simple dict.