### PR TITLE
Remove leading `\n` when rendering nodes

### DIFF
--- a/Sources/Swim/Node.swift
+++ b/Sources/Swim/Node.swift
@@ -26,7 +26,7 @@ public enum Node: Hashable {
 
 extension Node: TextOutputStreamable {
     public func write<Target>(to target: inout Target) where Target : TextOutputStream {
-        var flag = false
+        var flag = true
         var depth = 0
 
         write(to: &target, depth: &depth, didVisitTrim: &flag)

--- a/Tests/HTMLTests/HTMLTests.swift
+++ b/Tests/HTMLTests/HTMLTests.swift
@@ -50,11 +50,11 @@ final class HTMLTests: XCTestCase {
     func testEmptyElements() {
         let emptyElement = br()
 
-        XCTAssertEqual(String(describing: emptyElement), "\n<br/>")
+        XCTAssertEqual(String(describing: emptyElement), "<br/>")
 
         let nonEmptyElement = p()
 
-        XCTAssertEqual(String(describing: nonEmptyElement), "\n<p>\n</p>")
+        XCTAssertEqual(String(describing: nonEmptyElement), "<p>\n</p>")
     }
 
     func testIfBlock() {

--- a/Tests/SwimTests/SwimTests.swift
+++ b/Tests/SwimTests/SwimTests.swift
@@ -13,25 +13,25 @@ extension Node {
 final class SwimTests: XCTestCase {
     func testText() {
         let n: Node = "3 > 1"
-        XCTAssertEqual(n.rendered, "\n3 &gt; 1")
+        XCTAssertEqual(n.rendered, "3 &gt; 1")
     }
-    
+
     func testUnicodeAndEscaping() {
         let n: Node = "500 €"
         var result = ""
         n.write(to: &result)
-        XCTAssertEqual(result, "\n500 €")
+        XCTAssertEqual(result, "500 €")
     }
-    
+
     func testRaw() {
         let n: Node = Node.raw("<marquee>Hello</marquee>")
-        XCTAssertEqual(n.rendered, "\n<marquee>Hello</marquee>")
+        XCTAssertEqual(n.rendered, "<marquee>Hello</marquee>")
     }
-    
+
     func testAttributeWithQuote() {
         let n: Node = Node.element("a", [
             "x": "\""
         ], nil)
-        XCTAssertEqual(n.rendered, "\n<a x=\"&quot;\"/>")
+        XCTAssertEqual(n.rendered, "<a x=\"&quot;\"/>")
     }
 }


### PR DESCRIPTION
Not sure why having the output start with a new line didn't bother me sooner.

@chriseidhof I don't think this should have any adverse side effects, but maybe I'm missing something.
